### PR TITLE
Optimize build script

### DIFF
--- a/sources/build.sh
+++ b/sources/build.sh
@@ -15,12 +15,10 @@ rm -r master_ttf
 rm -rf ../fonts
 mkdir ../fonts
 
-mv autohinted/master_ttf ../fonts
-mv ../fonts/master_ttf ../fonts/ttf
+mv autohinted/master_ttf ../fonts/ttf
 rm -r autohinted
 
-mv master_otf ../fonts
-mv ../fonts/master_otf ../fonts/otf
+mv master_otf ../fonts/otf
 
 # Generate webfonts
 FONTS_TTF=$(ls ../fonts/ttf/*.ttf)

--- a/sources/build.sh
+++ b/sources/build.sh
@@ -2,9 +2,12 @@
 
 set -e # Stop script if we have any critical errors
 
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SRC_DIR=$REPO_ROOT/sources
+FONT_DIR=$REPO_ROOT/fonts
 
 # Generate fonts
-for font in $(ls -d *.ufo);
+for font in $(ls -d $SRC_DIR/*.ufo);
 do
     fontmake -u $font -a -o ttf
     fontmake -u $font -a -o otf
@@ -12,16 +15,16 @@ done
 
 # Tidyup up folders
 rm -r master_ttf 
-rm -rf ../fonts
-mkdir ../fonts
+rm -rf $FONT_DIR
+mkdir $FONT_DIR
 
-mv autohinted/master_ttf ../fonts/ttf
+mv autohinted/master_ttf $FONT_DIR/ttf
 rm -r autohinted
 
-mv master_otf ../fonts/otf
+mv master_otf $FONT_DIR/otf
 
 # Generate webfonts
-FONTS_TTF=$(ls ../fonts/ttf/*.ttf)
+FONTS_TTF=$(ls $FONT_DIR/ttf/*.ttf)
 
 # Generate .woff
 for font in $FONTS_TTF
@@ -31,10 +34,10 @@ do
 done
 
 # Move webfonts to seperate folders
-mkdir ../fonts/woff2
-mv ../fonts/ttf/*.woff2 ../fonts/woff2/
+mkdir $FONT_DIR/woff
+mv $FONT_DIR/ttf/*.woff $FONT_DIR/woff/
 
-mkdir ../fonts/woff
-mv ../fonts/ttf/*.woff ../fonts/woff/
+mkdir $FONT_DIR/woff2
+mv $FONT_DIR/ttf/*.woff2 $FONT_DIR/woff2/
 
 echo 'done'


### PR DESCRIPTION
The build script was dependent on the directory in which it was triggered. This could cause inconsistency if the script was triggered from outside it's own directory.

The global variables allows the script to run with respect to the root of the repository allowing more flexibility, stability and consistency.

Also, there were multiple `mv` commands that could be merged into a single command.