### PR TITLE
Update readme with information on installing dependencies on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,26 @@ virtualenv env
 source env/bin/activate
 
 pip install -r requirements.txt
+```
 
-# dependencies to generate webfonts
+## Dependencies to generate webfonts
+* sfnt2woff
+* [woff2](https://github.com/google/woff2)
+
+### Install on MacOS
+```
 brew tap bramstein/webfonttools
 brew update
 brew install bramstein/webfonttools/sfnt2woff
 brew install bramstein/webfonttools/woff2
 
 ```
+### Install on Linux
+Install the dependencies with the respective package manager for your distribution (eg. apt - Debian-based systems, dnf - Red Hat-based systems, etc)
+
+Note : Compiling [woff2](https://github.com/google/woff2) from source is fairly easy with no additional dependencies (other than the included submodules - brotli, terryfy, esaxx).
+#### Debian-based systems (aptitude | apt)
+`apt install woff-tools` (provides `sfnt2woff`)
 
 ## Generating fonts
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ brew install bramstein/webfonttools/woff2
 ### Install on Linux
 Install the dependencies with the respective package manager for your distribution (eg. apt - Debian-based systems, dnf - Red Hat-based systems, etc)
 
-Note : Compiling [woff2](https://github.com/google/woff2) from source is fairly easy with no additional dependencies (other than the included submodules - brotli, terryfy, esaxx).
+Note : Compiling [woff2](https://github.com/google/woff2) from source is fairly easy with no additional dependencies (other than the included submodules - [brotli](https://github.com/google/brotli), [terryfy](https://github.com/MacPython/terryfy), [esaxx](https://github.com/hillbig/esaxx)).
 #### Debian-based systems (aptitude | apt)
 `apt install woff-tools` (provides `sfnt2woff`)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pip install -r requirements.txt
 ```
 
 ## Dependencies to generate webfonts
+* ttfautohint
 * sfnt2woff
 * [woff2](https://github.com/google/woff2)
 
@@ -23,6 +24,7 @@ pip install -r requirements.txt
 ```
 brew tap bramstein/webfonttools
 brew update
+brew install ttfautohint
 brew install bramstein/webfonttools/sfnt2woff
 brew install bramstein/webfonttools/woff2
 
@@ -32,7 +34,7 @@ Install the dependencies with the respective package manager for your distributi
 
 Note : Compiling [woff2](https://github.com/google/woff2) from source is fairly easy with no additional dependencies (other than the included submodules - [brotli](https://github.com/google/brotli), [terryfy](https://github.com/MacPython/terryfy), [esaxx](https://github.com/hillbig/esaxx)).
 #### Debian-based systems (aptitude | apt)
-`apt install woff-tools` (provides `sfnt2woff`)
+`apt install ttfautohint woff-tools`
 
 ## Generating fonts
 


### PR DESCRIPTION
This change updates the [`README.md`](https://github.com/mozilla/zilla-slab/blob/master/README.md) file with appropriate information for installing dependencies on Linux.